### PR TITLE
Fix for issue #107

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,8 +81,12 @@ const kitchensinkConfig = Object.assign({}, defaultConfig, {
         chunkFilename: "[hash]/js/[id].js"
     },
     externals: {
-        'jquery': 'jQuery',
-        '$': 'jQuery'
+        'jquery': {
+            root: 'jQuery',
+            commonjs2: 'jquery',
+            commonjs: 'jquery',
+            amd: 'jquery'
+        }
     }
 });
 
@@ -94,8 +98,12 @@ const standardDistConfig = Object.assign({}, defaultConfig, {
         chunkFilename: "[hash]/js/[id].js"
     },
     externals: {
-        'jquery': 'jQuery',
-        '$': 'jQuery'
+        'jquery': {
+            root: 'jQuery',
+            commonjs2: 'jquery',
+            commonjs: 'jquery',
+            amd: 'jquery'
+        }
     }
 });
 


### PR DESCRIPTION
The follow changes do address the way jquery externals are used for webpack generated modules.

Also to get it working in the create-react-app in additional to the newly generated cbp-theme.js that uses the newly defined jQuery within those modules, I also modified my implementation to pull in those dependencies.

<img width="483" alt="screen shot 2017-08-12 at 10 15 20 am" src="https://user-images.githubusercontent.com/14062379/29241450-3ec4c694-7f48-11e7-9625-2dc4eccca08a.png">
