### PR TITLE
Fixes for issues # 187 & 188.

### DIFF
--- a/app/styles/custom/_buttons.scss
+++ b/app/styles/custom/_buttons.scss
@@ -33,6 +33,8 @@
 
 .input-group-btn:last-child>.btn, .input-group-btn:last-child>.btn-group {
   padding: $padding-base-vertical $padding-base-horizontal;
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 
 

--- a/app/styles/custom/_mixins.scss
+++ b/app/styles/custom/_mixins.scss
@@ -93,12 +93,6 @@
     margin: 1px 2px;
   }
 
-  /* yeah it's a hack -- 'cus of our one browser policy (aka IE11) -- sadness :(  */
-  *::-ms-backdrop, .btn {
-    padding: 7px 12px 8px;
-    top: 1px;
-  }
-
   [disabled].btn{
     background-color: $gray-darker !important;
     color: $white !important;


### PR DESCRIPTION
#### What's this PR do?

This PR fixes issue of button-padding in both Chrome & IE.

#### Where should the reviewer start?

The 2 files where changes occurred. 

#### How should this be manually tested?

To test use the markup used when issue was reported (issue # 187)

```
<div class="input-group">
    <input type="text" class=" form-control">
    <div class="input-group-btn">
        <button class="btn btn-default" type="button">
            <span aria-label="Lookup"><i aria-hidden="true" class="fa fa-search"></i></span>
        </button>
    </div>
</div>
```

#### Any background context you want to provide?

Issue was occurring because the **.btn** class was adding 1PX on the top & bottom margin which was causing the alignment problem.  I decided to have top & bottom margins set to 0PX in the classes **.input-group-btn:last-child>.btn**, .**input-group-btn:last-child>.btn-group** because if the margins were removed in the .btn class then it would casue a shift everywhere .btn was used. 
See screenshot below for example.

For IE I deleted the IE hack since it was causing an additional shift problems. 

#### What are the relevant tickets?

Tickets # 187 & 188.

#### Screenshots (if appropriate)

Following shows buttons without any changes to .btn class
<img width="269" alt="regbutton" src="https://user-images.githubusercontent.com/16483548/37349839-b9105492-26ad-11e8-8192-00c29989571d.PNG">

Following shows if .btn class top & bottom margins were removed.
<img width="265" alt="affected" src="https://user-images.githubusercontent.com/16483548/37349863-cad3d168-26ad-11e8-8508-980bb270f131.PNG">

Following is screenshot from IE (before & after respectively):
<img width="172" alt="iebug" src="https://user-images.githubusercontent.com/16483548/37349092-06bde616-26ac-11e8-8207-bc7f90b3736f.PNG">

<img width="192" alt="iefix" src="https://user-images.githubusercontent.com/16483548/37349100-0a7de4e0-26ac-11e8-9a49-7abd254b8fb9.PNG">

Screenshot from Chrome:
<img width="189" alt="chromebug" src="https://user-images.githubusercontent.com/16483548/37349136-1d256aaa-26ac-11e8-8588-750d85ea8a32.PNG">

<img width="203" alt="chromefix" src="https://user-images.githubusercontent.com/16483548/37349142-204756a8-26ac-11e8-8207-f95196049c1f.PNG">


#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
- Does this add new (Python) dependencies which need to be added to chef?
