### PR TITLE
Changed navbar default color from #777 to #555.

### DIFF
--- a/app/styles/custom/_variables.scss
+++ b/app/styles/custom/_variables.scss
@@ -374,12 +374,12 @@ $navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;
 $navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2) !default;
 $navbar-collapse-max-height:       340px !default;
 
-$navbar-default-color:             #777 !default;
+$navbar-default-color:             #555 !default;
 $navbar-default-bg:                #f8f8f8 !default;
 $navbar-default-border:            darken($navbar-default-bg, 6.5%) !default;
 
 // Navbar links
-$navbar-default-link-color:                #777 !default;
+$navbar-default-link-color:                #555 !default;
 $navbar-default-link-hover-color:          #333 !default;
 $navbar-default-link-hover-bg:             transparent !default;
 $navbar-default-link-active-color:         #555 !default;


### PR DESCRIPTION
#### What's this PR do?
Changes variables:
$navbar-default-color: #777 !default;
$navbar-default-link-color: #777 !default;

to

$navbar-default-color: #555 !default;
$navbar-default-link-color: #555 !default;

#### Where should the reviewer start?
Look at _variable.scss
#### How should this be manually tested?
Run locally.  From dev tool create new element with .navbar-text class. 
#### Any background context you want to provide?
#### What are the relevant tickets?
198
#### Screenshots (if appropriate)
Color #777
<img width="655" alt="navbarcolor777" src="https://user-images.githubusercontent.com/16483548/38569588-a9e392dc-3cb9-11e8-8d1c-ee45705087a1.PNG">


Color #555
<img width="585" alt="navbarcolor555" src="https://user-images.githubusercontent.com/16483548/38569594-ad5af75c-3cb9-11e8-8732-229cd782b44b.PNG">

#### Questions:
- Is there a blog post?
No
- Does the knowledge base need an update?
