### PR TITLE
chore: excluding node_modules in ds website on GitHub pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-cbp-ds": "cd ds-css && npm run build",
     "init-cbp-ds-ux": "cd ds-ux-guidelines && npm install",
     "build-cbp-ds-ux": "cd ds-ux-guidelines && npm run build:guide",
-    "copy-ds-to-cbp-theme": "cp -rf ds-css/dist cbp-theme/kitchensink/ds-css && cp -rf ds-ux-guidelines/. cbp-theme/kitchensink/design-system"
+    "copy-ds-to-cbp-theme": "cp -rf ds-css/dist cbp-theme/kitchensink/ds-css && rsync -av --progress --exclude='node_modules' ds-ux-guidelines/ cbp-theme/kitchensink/design-system/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
What's this PR do?
Fixes the publishing to GitHub pages for the design system. Currently the publishing fails in Travis CI because the node_modules are too large.

https://travis-ci.org/US-CBP/cbp-theme/builds/612034874?utm_medium=notification&utm_source=slack

Where should the reviewer start?
Start with the root package.json the copy-ds-to-cbp-theme

How should this be manually tested?
Run the init commands, build commands and finally the copy command and verify the cbp-theme/kitchensink directory has the design-system files sans the node_modules.

Any background context you want to provide?
The change uses rsync so ensure that you test where you can use rsysnc

What are the relevant tickets?
Screenshots (if appropriate)
Questions:
Is there a blog post? N/A
Does the knowledge base need an update? N/A