### PR TITLE
Adjust line-height to h1 & added body text class in helpers.scss

### DIFF
--- a/ds-css/src/styles/custom/base/helpers.scss
+++ b/ds-css/src/styles/custom/base/helpers.scss
@@ -32,7 +32,7 @@
 .cbp-heading-1 {
   font-size: 2.027rem;
   font-weight: $cbp-weight-light;
-  line-height: $cbp-height-40;
+  line-height: $cbp-height-36;
   letter-spacing: $cbp-font-spacing;
   
   &--dark {
@@ -90,6 +90,17 @@
   line-height: $cbp-height-20;
   letter-spacing: $cbp-font-spacing;
   
+  &--dark {
+    @include dark;
+  }
+}
+
+.cbp-body {
+  font-size: 1rem;
+  font-weight: $cbp-weight-regular;
+  line-height: $cbp-height-20;
+  letter-spacing: $cbp-font-spacing;
+
   &--dark {
     @include dark;
   }

--- a/ds-css/src/styles/custom/utilities/initial-variables.scss
+++ b/ds-css/src/styles/custom/utilities/initial-variables.scss
@@ -104,5 +104,6 @@ $cbp-height-20: 20px;
 $cbp-height-24: 24px;
 $cbp-height-28: 28px;
 $cbp-height-32: 32px;
+$cbp-height-36: 36px;
 $cbp-height-40: 40px;
 $cbp-height-44: 44px;


### PR DESCRIPTION
#### What's this PR do?
Change the line-height of h1 to 36px  and add a new .cbp-body class 

#### Where should the reviewer start?
The modified sass files in ds-css (2 files)

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
We may need to revisit generic.scss to clean up some of the variables under html & body. Some of the elements are used for the body text, which needs its own class (which has been created in this PR). Can provide more info if needed.

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions:
- Is there a blog post? No
- Does the knowledge base need an update? No
