### PR TITLE
chore: updated mdl related libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5179,7 +5179,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5375,8 +5374,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5466,8 +5464,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8344,9 +8341,9 @@
       }
     },
     "material-design-lite": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.1.1.tgz",
-      "integrity": "sha1-XrVac4UbNZnjyDLJM1eCqC6ExxE="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.3.0.tgz",
+      "integrity": "sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM="
     },
     "math-random": {
       "version": "1.0.4",
@@ -8355,18 +8352,11 @@
       "dev": true
     },
     "mdl-selectfield": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mdl-selectfield/-/mdl-selectfield-1.0.2.tgz",
-      "integrity": "sha1-5t8ejqNMp0e02XPQCxbsXdWk0ec=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mdl-selectfield/-/mdl-selectfield-1.0.4.tgz",
+      "integrity": "sha1-fQXN0z6bW+SlxNDTIlWAQbhSmsk=",
       "requires": {
         "material-design-lite": "^1.1.3"
-      },
-      "dependencies": {
-        "material-design-lite": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.3.0.tgz",
-          "integrity": "sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM="
-        }
       }
     },
     "mdn-data": {

--- a/package.json
+++ b/package.json
@@ -128,8 +128,8 @@
     "bootstrap-sass": "3.4.1",
     "font-awesome": "4.6.3",
     "jquery": "3.4.1",
-    "material-design-lite": "1.1.1",
-    "mdl-selectfield": "1.0.2",
+    "material-design-lite": "1.3.0",
+    "mdl-selectfield": "1.0.4",
     "roboto-fontface": "0.10.0"
   }
 }


### PR DESCRIPTION
- this will be last update for cbp-theme
- the mdl 1.3.0 version is the last supported version of material-design-lite

#### What's this PR do?
Upgrade mdl relaated libraries:
https://www.npmjs.com/package/material-design-lite
https://www.npmjs.com/package/mdl-selectfield

#### Where should the reviewer start?

package.json

#### How should this be manually tested?
npm i 
npm run build
npm run dev

#### Any background context you want to provide?

This addresses some issues with the theme and printing, this is also the last update for cbp theme

#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
