### PR TITLE
re-adjusted positioning & size of sidenav text items

### DIFF
--- a/ds-css/src/styles/custom/components/menu.scss
+++ b/ds-css/src/styles/custom/components/menu.scss
@@ -1,11 +1,14 @@
 .menu {
   overflow-y: auto;
-  padding: 24px;
+  // padding: 24px;
   background-color: $grey-lightest;
   font-size: $cbp-body-text;
+  padding: 0;
+  margin: 0;
 }
 
 .menu-list {
+  font-size: 1rem;
   > li {
     a {
       &:hover {
@@ -18,5 +21,9 @@
 }
 
 .menu-label {
-  font-size: $cbp-size-6;
+  display:block;
+  position: relative;
+  left: 28px;
+  font-weight: bold;
+  margin-top: 10px;
 }

--- a/ds-css/src/styles/custom/components/menu.scss
+++ b/ds-css/src/styles/custom/components/menu.scss
@@ -21,7 +21,6 @@
 }
 
 .menu-label {
-  display:block;
   position: relative;
   left: 28px;
   font-weight: bold;

--- a/ds-ux-guidelines/src/ds-common-styles/ds-common-styles.scss
+++ b/ds-ux-guidelines/src/ds-common-styles/ds-common-styles.scss
@@ -65,5 +65,16 @@ section {
 
 .dropdown-content, .dropdown-trigger {
   position: relative;
-  bottom: 15px;
+  left: 18px;
+  top: 5px;
+
+}
+
+.dropdown-container {
+  margin-bottom: 2rem;
+}
+
+.menu-text {
+  position: relative;
+  left: 18px;
 }

--- a/ds-ux-guidelines/src/ds-components/header/header.js
+++ b/ds-ux-guidelines/src/ds-components/header/header.js
@@ -19,7 +19,7 @@ const Header = ({ title }) => (
     
       <div className="level-right">
         <a href="#noId" className="is-size-7">
-          &nbsp; Changelog
+          &nbsp; &nbsp; Changelog
         </a>
         &nbsp;
         <a href="#noId" className="is-size-7">

--- a/ds-ux-guidelines/src/ds-components/navigation/navigation.js
+++ b/ds-ux-guidelines/src/ds-components/navigation/navigation.js
@@ -60,32 +60,32 @@ class Navigation extends Component {
           {
             name: "Tables",
             link: "/components/tables",
-            anchors: [
-              {
-                name: "Description",
-                id: "/components/tables/#description",
-              },
-              {
-                name: "Code",
-                id: "/components/tables/#code",
-              },
-              {
-                name: "Modifiers",
-                id: "/components/tables/#modifiers",
-              },
-              {
-                name: "General",
-                id: "/components/tables/#general",
-              },
-              {
-                name: "Usage",
-                id: "/components/tables/#usage",
-              },
-              {
-                name: "Accessibility",
-                id: "/components/tables/#accessibility",
-              },
-            ],
+            // anchors: [
+            //   {
+            //     name: "Description",
+            //     id: "/components/tables/#description",
+            //   },
+            //   {
+            //     name: "Code",
+            //     id: "/components/tables/#code",
+            //   },
+            //   {
+            //     name: "Modifiers",
+            //     id: "/components/tables/#modifiers",
+            //   },
+            //   {
+            //     name: "General",
+            //     id: "/components/tables/#general",
+            //   },
+            //   {
+            //     name: "Usage",
+            //     id: "/components/tables/#usage",
+            //   },
+            //   {
+            //     name: "Accessibility",
+            //     id: "/components/tables/#accessibility",
+            //   },
+            // ],
           },
         ],
       },
@@ -102,26 +102,23 @@ class Navigation extends Component {
   }
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.handleClose);
-  };
+    document.addEventListener("mousedown", this.handleClose)
+  }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClose);
-  };
+    document.removeEventListener("mousedown", this.handleClose)
+  }
 
   menuList = () => {
-    /*     return (
-      <li>WORKING</li>
-    ) */
     const menuList = this.state.categories.map(cat => {
       return (
         <>
-          <p className="menu-label">{cat.name}</p>
+          <span className="menu-label">{cat.name}</span>
           <ul className="menu-list">
             {cat.subcategory.map(subCat => {
               return (
                 <li>
-                  <Link to={subCat.link}>{subCat.name}</Link>
+                  <Link to={subCat.link}><span className="menu-text">{subCat.name}</span></Link>
 
                   {subCat.anchors !== undefined ||
                   subCat.anchors !== undefined ? (
@@ -134,79 +131,78 @@ class Navigation extends Component {
                               to={anchor.id}
                               key={`.${anchor.name.replace(/\s/g, "")}-item`}
                             >
-                              {anchor.name}
+                              <span className="menu-text">{anchor.name}</span>
                             </Link>
                           </li>
                         )
                       })}
                     </ul>
                   ) : null}
-                  {/*                       <ul style={{borderLeft: "solid 1px #aaaa98"}}>
-
-                      </ul> */}
                 </li>
               )
             })}
           </ul>
+          <br />
         </>
       )
     })
-
-    //console.log('MenuList: ',menuList);
     return menuList
   }
 
   //toggle function for dropdown
-  toggleDropdown = (e) => {
-    e.preventDefault();
-    const currentState = this.state.showDropdown;
-    this.setState({ showDropdown: !currentState });
-    return;
-  };
+  toggleDropdown = e => {
+    e.preventDefault()
+    const currentState = this.state.showDropdown
+    this.setState({ showDropdown: !currentState })
+    return
+  }
 
   //dropdown handle close when clicked outside of dropdown
   handleClose = event => {
-    if(this.node && !this.node.contains(event.target)){
-      this.setState({ showDropdown: false }); 
-    };
-    
-    return;
-  };
+    if (this.node && !this.node.contains(event.target)) {
+      this.setState({ showDropdown: false })
+    }
+
+    return
+  }
 
   render() {
     return (
       <>
         {/* cbp-ds-grid class is the main grid holder. */}
         <aside className="menu">
-          <div
-            ref={node => this.node = node}
-            className={`dropdown ${
-              this.state.showDropdown ? "is-active" : null
-            }`}
-          >
-            <div className="dropdown-trigger">
-              <button
-                onClick={this.toggleDropdown}
-                className="button is-small"
-                aria-haspopup="true"
-                aria-controls="dropdown-menu"
-                style={{ width: "100%" }}
-              >
-                <span>CBP Theme Version 2.0</span>
-                &nbsp; <i className="fas fa-angle-down" aria-hidden="true"></i>
-              </button>
-            </div>
-
-            <div className="dropdown-menu" id="dropdown-menu" role="menu">
-              <div className="dropdown-content">
-                <a
-                  href="https://us-cbp.github.io/cbp-style-guide/docs/index.html"
-                  className="dropdown-item"
-                  target="_blank"
-                  rel="noopener noreferrer"
+          <div className="dropdown-container">
+            <div
+              ref={node => (this.node = node)}
+              className={`dropdown ${
+                this.state.showDropdown ? "is-active" : null
+              }`}
+            >
+              <div className="dropdown-trigger">
+                <button
+                  onClick={this.toggleDropdown}
+                  className="button is-small"
+                  aria-haspopup="true"
+                  aria-controls="dropdown-menu"
+                  style={{ width: "100%" }}
                 >
-                  CBP THEME VERSION 1.11.0
-                </a>
+                  <span>CBP Theme Version 2.0</span>
+                  &nbsp;{" "}
+                  <i className="fas fa-angle-down" aria-hidden="true"></i>
+                </button>
+              </div>
+
+              <div className="dropdown-menu" id="dropdown-menu" role="menu">
+                <div className="dropdown-content">
+                  <a
+                    href="https://us-cbp.github.io/cbp-style-guide/docs/index.html"
+                    className="dropdown-item"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    CBP THEME VERSION 1.11.0
+                  </a>
+                </div>
               </div>
             </div>
           </div>

--- a/ds-ux-guidelines/src/ds-components/navigation/navigation.js
+++ b/ds-ux-guidelines/src/ds-components/navigation/navigation.js
@@ -113,7 +113,7 @@ class Navigation extends Component {
     const menuList = this.state.categories.map(cat => {
       return (
         <>
-          <span className="menu-label">{cat.name}</span>
+          <span className="menu-label" style={{fontSize: "1rem"}}>{cat.name}</span>
           <ul className="menu-list">
             {cat.subcategory.map(subCat => {
               return (


### PR DESCRIPTION
#### What's this PR do?
Improves text hierarchy on the sidenav with the following:
- Bolded main headings
- Align left margin to be equal to each other

Added highlighting to entire item 

#### Where should the reviewer start?

#### How should this be manually tested?
build `ds-css` and `ds-ux-guidelines`, and check to see that the sidenav is the same as the screenshot attached.

#### Any background context you want to provide?
I'm having trouble getting the sub-items on the sidenav to highlight correctly. Please take a look at your convenience. 

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
<img width="277" alt="Screen Shot 2020-03-24 at 2 38 00 PM" src="https://user-images.githubusercontent.com/13155212/77464126-18d47c00-6ddd-11ea-8e38-1356755bf67f.png">


#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
