### PR TITLE
chore: added a development layout scss file

### DIFF
--- a/ds-ux-guidelines/gatsby-config.js
+++ b/ds-ux-guidelines/gatsby-config.js
@@ -6,7 +6,14 @@ module.exports = {
     author: `Creative Services`,
   },
   plugins: [
-    `gatsby-plugin-sass`,
+    {
+      resolve: `gatsby-plugin-sass`,
+      options: {
+        includePaths: [
+          require('path').resolve(__dirname, 'node_modules')
+        ]
+      }
+    },
     `gatsby-plugin-smoothscroll`,
     `gatsby-plugin-react-helmet`,
     {

--- a/ds-ux-guidelines/package-lock.json
+++ b/ds-ux-guidelines/package-lock.json
@@ -4021,6 +4021,11 @@
         "url-to-options": "^1.0.1"
       }
     },
+    "cbp-ds": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/cbp-ds/-/cbp-ds-2.0.14.tgz",
+      "integrity": "sha512-mMG5mD1cTrmdwXUOvQ2GvEMKNOzOpgwGS+ZBQgkUpqy8BN3WB4eIDNBLnua0wOT38aKhrvWmB5BjTZzfstZRuw=="
+    },
     "ccount": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",

--- a/ds-ux-guidelines/package.json
+++ b/ds-ux-guidelines/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "author": "Creative Services",
   "dependencies": {
+    "cbp-ds": "^2.0.14",
     "gatsby": "^2.20.10",
     "gatsby-image": "^2.2.39",
     "gatsby-plugin-manifest": "^2.3.3",
@@ -35,9 +36,9 @@
     "stylelint-scss": "^3.14.2"
   },
   "keywords": [
-    "gatsby"
+    "cbp design system,cbp theme,gatsby"
   ],
-  "license": "MIT",
+  "license": "CC0-1.0",
   "scripts": {
     "build": "gatsby build --prefix-paths",
     "clean": "gatsby clean",

--- a/ds-ux-guidelines/src/ds-components/layout/layout-development.scss
+++ b/ds-ux-guidelines/src/ds-components/layout/layout-development.scss
@@ -1,9 +1,9 @@
-@import "~cbp-ds/cbp-ds.min.css";
+@import "../../../../ds-css/dist/css/cbp-ds.min.css";
 
 @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css");
 @import url("https://fonts.googleapis.com/css?family=Roboto:300,400,600,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@100;300;400;500;700&display=swap");
-
+@import url('https://us-cbp.github.io/cbp-theme/design-system/css/updated-styles.css');
 @import "../../ds-common-styles/ds-common-styles.scss";
 /*
   !!!!! IMPORTANT: All scss files are, and should be imported into layout.scss !!!!!

--- a/ds-ux-guidelines/src/ds-components/layout/layout.js
+++ b/ds-ux-guidelines/src/ds-components/layout/layout.js
@@ -11,7 +11,24 @@ import { useStaticQuery, graphql } from "gatsby"
 
 import Header from "../header/header"
 import Navigation from "../navigation/navigation"
-import "./layout.scss"
+
+// Development is set when running gatsby
+// gastby develop - sets the environment to development
+// gatsby build and serve - sets the environment to production
+if (process.env.NODE_ENV === `development`) {
+  try {
+    require("./layout-development.scss")
+  } catch (e) {
+    console.log(e)
+  }
+} else {
+  try {
+    require("./layout.scss")
+  } catch (e) {
+    console.log(e)
+  }
+}
+
 
 const Layout = ({ children }) => {
   const data = useStaticQuery(graphql`


### PR DESCRIPTION
- gatsby develop - sets the environment to development
- gatsby build and serve - sets the environment to production
- there are two different layout scss files:
  development.scss pulls in the local ds-css folder cbp-ds.css
  layout.scss pulls in the npm published cbp-ds version of css
- added cbp-ds to package dependencies

#### What's this PR do?
Pulls in either the local ds-css folder for development and npm cbp-ds version for production

#### Where should the reviewer start?

package.json, layout-development.scss, layout.js, layout.scss, gatsby-config.js

Note that gatsby is built on webpack and the ~ is how to pull in node modules

#### How should this be manually tested?

npm run develop 
ensure everything works correctly and optionally make changes to the local ds-css

npm run build && npm run serve
ensure everything works correctly and make changes to the local ds-css, it should not be picked up.

Also, you can inspect the css in the page
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
