### PR TITLE
adjust max-width of line length in spacing wrapper

### DIFF
--- a/ds-css/src/styles/custom/base/helpers.scss
+++ b/ds-css/src/styles/custom/base/helpers.scss
@@ -99,6 +99,7 @@
   font-weight: $cbp-weight-regular;
   line-height: $cbp-height-20;
   letter-spacing: $cbp-font-spacing;
+  max-width: 75em;
 
   &--dark {
     @include dark;
@@ -135,18 +136,23 @@
   &--micro {
     padding: $cbp-micro-space;
   }
+
   &--xsmall {
     padding: $cbp-extra-sm-space;
   }
+
   &--small {
     padding: $cbp-sm-space;
   }
+
   &--regular {
     padding: $cbp-reg-space;
   }
+
   &--large {
     padding: $cbp-lg-space;
   }
+
   &--xlarge {
     padding: $cbp-extra-lg-space;
   }
@@ -157,15 +163,19 @@
   &--micro {
     padding: $cbp-micro-space $cbp-extra-sm-space;
   }
+
   &--xsmall {
     padding: $cbp-extra-sm-space $cbp-sm-space;
   }
+
   &--small {
     padding: $cbp-sm-space $cbp-reg-space;
   }
+
   &--regular {
     padding: $cbp-reg-space $cbp-lg-space;
   }
+
   &--large {
     padding: $cbp-lg-space $cbp-extra-lg-space;
   }
@@ -176,15 +186,19 @@
   &--micro {
     padding: $cbp-extra-sm-space $cbp-micro-space;
   }
+
   &--xsmall {
     padding: $cbp-sm-space $cbp-extra-sm-space;
   }
+
   &--small {
     padding: $cbp-reg-space $cbp-sm-space;
   }
+
   &--regular {
     padding: $cbp-lg-space $cbp-reg-space;
   }
+
   &--large {
     padding: $cbp-extra-lg-space $cbp-lg-space;
   }
@@ -195,18 +209,23 @@
   &--micro {
     padding-bottom: $cbp-micro-space;
   }
+
   &--xsmall {
     padding-bottom: $cbp-extra-sm-space;
   }
+
   &--small {
     padding-bottom: $cbp-sm-space;
   }
+
   &--regular {
     padding-bottom: $cbp-reg-space;
   }
+
   &--large {
     padding-bottom: $cbp-lg-space;
   }
+
   &--xlarge {
     padding-bottom: $cbp-extra-lg-space;
   }

--- a/ds-ux-guidelines/src/ds-common-styles/ds-common-styles.scss
+++ b/ds-ux-guidelines/src/ds-common-styles/ds-common-styles.scss
@@ -13,6 +13,8 @@ iframe {
 
 .spacing-wrapper {
   padding: 0 $cbp-reg-space $cbp-lg-space $cbp-reg-space !important;
+  max-width: 75em;
+
 
   //hides the default scroll bar from react-tabs TabPanel
   overflow: hidden !important;


### PR DESCRIPTION
#### What's this PR do?
Quick adjustment to line length that sets a failsafe of 75em of body copy in the DS, as well as setting spacing wrapper around main content to 75em.

#### Where should the reviewer start?
`ds-common-styles.scss`, `helpers.scss`

#### How should this be manually tested?
Check to see if all pages have had their line length adjusted properly.

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
